### PR TITLE
chore: do not re-deploy current tag

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -37,13 +37,11 @@ case "$action" in
     $dir/start.sh --slave
     ;;
   deploy)
-    $dir/prepare.sh --slave
-    $dir/rollout.sh --slave
+    $dir/prepare.sh --slave && $dir/rollout.sh --slave && notify deploy done
     ;;
   rollback)
     $dir/rollback.sh --slave
     ;;
 esac
 
-notify deploy done
 exit 0

--- a/prepare.sh
+++ b/prepare.sh
@@ -13,12 +13,20 @@ if [ "$1" != "--slave" ]
     prompt DEPLOY_DIR --skip
     prompt GIT_CHECKOUT --skip
 fi
-
-[[ "$GIT_CHECKOUT" == "latest" ]] && export GIT_CHECKOUT=$(getLatestTag)
-
 ########################
 
 notify prepare start
+
+if [[ "$GIT_CHECKOUT" == "latest" ]]
+  then
+    export GIT_CHECKOUT=$(getLatestTag)
+    export CURRENT_CHECKOUT=$(getCurrentCheckout)
+    if [[ "$GIT_CHECKOUT" == "$CURRENT_CHECKOUT" ]]
+      then
+        notify deploy skipped
+        exit 1
+    fi
+fi
 
 cd $DEPLOY_DIR
 

--- a/setup.sh
+++ b/setup.sh
@@ -20,21 +20,21 @@ fi
 
 write_config
 
-pm2 kill
+pm2 kill > /dev/null 2>&1
 
 chmod +x $dir/prepare.sh
 chmod +x $dir/rollout.sh
 chmod +x $dir/start.sh
 chmod +x $dir/rollback.sh
 
-rm -rf $DEPLOY_DIR/next
-rm -rf $DEPLOY_DIR/app
-rm -rf $DEPLOY_DIR/prev
-rm -rf $DEPLOY_DIR/logs
+rm -rf $DEPLOY_DIR/next > /dev/null 2>&1
+rm -rf $DEPLOY_DIR/app > /dev/null 2>&1
+rm -rf $DEPLOY_DIR/prev > /dev/null 2>&1
+rm -rf $DEPLOY_DIR/logs > /dev/null 2>&1
 
-mkdir $DEPLOY_DIR/next
-mkdir $DEPLOY_DIR/app
-mkdir $DEPLOY_DIR/prev
-mkdir $DEPLOY_DIR/logs
+mkdir -p $DEPLOY_DIR/next
+mkdir -p $DEPLOY_DIR/app
+mkdir -p $DEPLOY_DIR/prev
+mkdir -p $DEPLOY_DIR/logs
 
 log "All set! Happy coding!"


### PR DESCRIPTION
## Type of change:
<!-- Delete non relevant  -->
### 👀 Miscellaneous

## Description:
Skips deployment if current "tag" is already deployed.

Should be configured to deploy "latest".

## Implementation:
Adds a check in `prepare` script.

## Issues:
n/a

## Demo:
![изображение](https://user-images.githubusercontent.com/10243265/120617262-3af27100-c45a-11eb-849b-51244ef18a94.png)

## Checklist:
- [x] ✔ _**`Applicable:`**_ 👇
- [x] Tested locally 
- [x] Potential regression checked
- [x] Code style and naming conventions checked
- [x] No new warnings introduced (browser and server)
- [x] Code that PR depends on is already merged
- [x] PR is "production" safe
- [x] ❌ _**`Not applicable:`**_ 👇
- [x] Tested review application
- [x] Review application was shown to QA - {slack-username}
- [x] Review application was shown to change initiator - {slack-username}
- [x] All related translations are available
